### PR TITLE
修改两处图片注释错误

### DIFF
--- a/blocks-items/bamboo-decorations.md
+++ b/blocks-items/bamboo-decorations.md
@@ -6,11 +6,11 @@
 
 ![竹子 * 3 + 竹板 * 3 → 竹椅 * 1](../.gitbook/assets/recipes/bamboo_chair_recipe.png)
 
-![竹子 * 4 + 竹板 * 3 → 竹椅 * 1](../.gitbook/assets/recipes/bamboo_table_recipe.png)
+![竹子 * 4 + 竹板 * 3 → 竹桌 * 1](../.gitbook/assets/recipes/bamboo_table_recipe.png)
 
 ![火把 * 1 + 竹子 * 8 → 竹灯 * 1](../.gitbook/assets/recipes/bamboo_lantern_recipe.png)
 
 ![竹板 * 6 → 竹门 * 3](../.gitbook/assets/recipes/bamboo_door_recipe.png)
 
-![玻璃 * 2 + 竹板 * 3 → 竹玻璃门 * 3](../.gitbook/assets/recipes/bamboo_glass_door_recipe.png)
+![玻璃 * 2 + 竹板 * 4 → 竹玻璃门 * 3](../.gitbook/assets/recipes/bamboo_glass_door_recipe.png)
 


### PR DESCRIPTION
1. 修正竹桌的图片注释。
2. 竹玻璃门图片注释中竹板的数量有误，已经订正。

考虑到图片加载不出的时候会显示图片注释，
保证图片注释正确还是有必要的。